### PR TITLE
Fix links in VaadinIcons javadoc

### DIFF
--- a/vaadin-icons/src/main/java/com/vaadin/icons/VaadinIcons.java
+++ b/vaadin-icons/src/main/java/com/vaadin/icons/VaadinIcons.java
@@ -19,7 +19,10 @@ import com.vaadin.server.FontIcon;
 
 /**
  * {@link FontIcon} that represents the <a
- * href="https://vaadin.com/vaadin-icons">Vaadin Icons font</a>.
+ * href="https://pro.vaadin.com/icons">Vaadin Icons font</a>. Read the Vaadin
+ * Documentation on <a
+ * href="https://vaadin.com/docs/v8/framework/themes/themes-fonticon.html">Font
+ * Icons</a> for more information on how to use the icons with your app.
  * 
  * @author Teemu Pöntelin, Vaadin Ltd (add-on)
  * @author Jarmo Kemppainen, Vaadin Ltd (font)


### PR DESCRIPTION
The link in VaadinIcons.java javadoc is broken and points into Vaadin Platform

Fixes https://github.com/vaadin/framework/issues/10804

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-icons-addon/17)
<!-- Reviewable:end -->
